### PR TITLE
サイドバー表示の閾値変更

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -201,7 +201,7 @@ onMount(() => {
 	transition: width 0.1s;
 	max-width: 100%;
 }
-@media screen and (min-width: 1080px) {
+@media screen and (min-width: 1078px) {
     #sidebar {
         min-width: 380px;
     }


### PR DESCRIPTION
Win11標準のウィンドウ分割機能で横1080pxサイズモニタを扱うとウィンドウサイズが自動で1078pxになってしまうようです。なのでサイドバー表示の閾値を1080から1078にしました。多少個人的な事情でもあるので問題あれば蹴ってください。