### PR TITLE
テーマの選択を保存できるように #75

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
 		"": {
 			"name": "unyu-house",
 			"version": "0.0.1",
+			"dependencies": {
+				"svelte-persisted-store": "^0.7.0"
+			},
 			"devDependencies": {
 				"@emoji-mart/data": "^1.1.2",
 				"@sveltejs/adapter-auto": "^2.1.1",
@@ -25,7 +28,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
 			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -405,7 +407,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
 			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -419,7 +420,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
 			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -428,7 +428,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -436,14 +435,12 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-			"dev": true
+			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
 			"integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -663,8 +660,7 @@
 		"node_modules/@types/estree": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
-			"dev": true
+			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.11",
@@ -699,7 +695,6 @@
 			"version": "8.10.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
 			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -724,7 +719,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
 			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
 			}
@@ -733,7 +727,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
 			"integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
-			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
 			}
@@ -824,7 +817,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
 			"integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15",
 				"@types/estree": "^1.0.1",
@@ -852,7 +844,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
 			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-			"dev": true,
 			"dependencies": {
 				"mdn-data": "2.0.30",
 				"source-map-js": "^1.0.1"
@@ -897,7 +888,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -976,7 +966,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
@@ -1176,7 +1165,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
 			"integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -1193,14 +1181,12 @@
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-			"dev": true
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.5",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.5.tgz",
 			"integrity": "sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			},
@@ -1211,8 +1197,7 @@
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-			"dev": true
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -1385,7 +1370,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
 			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0",
 				"estree-walker": "^3.0.0",
@@ -1603,7 +1587,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -1624,7 +1607,6 @@
 			"version": "4.2.8",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.8.tgz",
 			"integrity": "sha512-hU6dh1MPl8gh6klQZwK/n73GiAHiR95IkFsesLPbMeEZi36ydaXL/ZAb4g9sayT0MXzpxyZjR28yderJHxcmYA==",
-			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",
@@ -1676,6 +1658,17 @@
 			},
 			"peerDependencies": {
 				"svelte": "^3.19.0 || ^4.0.0"
+			}
+		},
+		"node_modules/svelte-persisted-store": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/svelte-persisted-store/-/svelte-persisted-store-0.7.0.tgz",
+			"integrity": "sha512-PczYS60ysScQ0DmTCPXQm5rwt8FfQzSlx0lCbljbE6hTCKqXaw2bP8KH1+B7QTPmuiy/QbAk4pjYpNCmZhjyRw==",
+			"engines": {
+				"node": ">=0.14"
+			},
+			"peerDependencies": {
+				"svelte": "^3.48.0 || >4.0.0"
 			}
 		},
 		"node_modules/svelte-preprocess": {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
 		"typescript": "^5.3.2",
 		"vite": "^4.5.1"
 	},
-	"type": "module"
+	"type": "module",
+	"dependencies": {
+		"svelte-persisted-store": "^0.7.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,10 @@
 		"nostr-tools": "^1.17.0",
 		"svelte": "^4.2.8",
 		"svelte-check": "^3.6.2",
+		"svelte-persisted-store": "^0.7.0",
 		"tslib": "^2.4.1",
 		"typescript": "^5.3.2",
 		"vite": "^4.5.1"
 	},
-	"type": "module",
-	"dependencies": {
-		"svelte-persisted-store": "^0.7.0"
-	}
+	"type": "module"
 }

--- a/src/app.html
+++ b/src/app.html
@@ -4,6 +4,15 @@
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width" />
+		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/water.css@2/out/dark.css">
+		<script>
+			const onLoaded = () => {
+				const loadedTheme = JSON.parse(localStorage.getItem('preferences') ?? '').theme ?? "https://cdn.jsdelivr.net/npm/water.css@2/out/dark.css";
+				const stylesheetLink = document.querySelector('link[rel=stylesheet]');
+				stylesheetLink.href = loadedTheme;
+			}
+			onLoaded();
+		</script>
 		%sveltekit.head%
 	</head>
 	<body data-sveltekit-preload-data="hover">

--- a/src/lib/components/Page.svelte
+++ b/src/lib/components/Page.svelte
@@ -1,7 +1,7 @@
 <script lang='ts'>
 import { type Channel, type Profile, type GetRelays, getRelaysToUse, RelayConnector, urlDefaultTheme } from '$lib/util';
 import type { NostrAPI } from '$lib/@types/nostr';
-import { storedIsLoggedin, storedLoginpubkey, storedCurrentChannelId, storedCurrentPubkey, storedCurrentHashtag, storedCurrentEvent, storedNeedApplyRelays, storedRelaysToUse, storedTheme } from '$lib/store';
+import { storedIsLoggedin, storedLoginpubkey, storedCurrentChannelId, storedCurrentPubkey, storedCurrentHashtag, storedCurrentEvent, storedNeedApplyRelays, storedRelaysToUse, preferences } from '$lib/store';
 import { defaultRelays, title } from '$lib/config';
 import { browser } from '$app/environment';
 import { afterNavigate, beforeNavigate } from '$app/navigation';
@@ -44,8 +44,8 @@ let scrolled: boolean = false;
 storedRelaysToUse.subscribe((value) => {
 	relaysToUse = value;
 });
-storedTheme.subscribe((value) => {
-	theme = value;
+preferences.subscribe((value) => {
+	theme = value.theme ?? theme;
 });
 storedCurrentChannelId.subscribe((value) => {
 	currentChannelId = value;
@@ -329,7 +329,10 @@ $: repostListToShow = currentChannelId ? repostList.filter(ev16 => {
 
 <svelte:head>
 	<title>{titleString}</title>
-	<link rel="stylesheet" href="{theme || urlDefaultTheme}">
+	<link rel="stylesheet" href="{theme}">
+	<script>
+        document.querySelector("link[rel=stylesheet]").href = JSON.parse(localStorage.getItem('preferences') ?? '').theme ?? urlDefaulttheme;;
+	</script>
 </svelte:head>
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->

--- a/src/lib/components/Page.svelte
+++ b/src/lib/components/Page.svelte
@@ -46,6 +46,9 @@ storedRelaysToUse.subscribe((value) => {
 });
 preferences.subscribe((value) => {
 	theme = value.theme ?? theme;
+	if (browser) {
+		(document.querySelector('link[rel=stylesheet]') as HTMLLinkElement).href = theme ?? $preferences.theme;
+	}
 });
 storedCurrentChannelId.subscribe((value) => {
 	currentChannelId = value;
@@ -329,10 +332,6 @@ $: repostListToShow = currentChannelId ? repostList.filter(ev16 => {
 
 <svelte:head>
 	<title>{titleString}</title>
-	<link rel="stylesheet" href="{theme}">
-	<script>
-        document.querySelector("link[rel=stylesheet]").href = JSON.parse(localStorage.getItem('preferences') ?? '').theme ?? urlDefaulttheme;;
-	</script>
 </svelte:head>
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -5,7 +5,7 @@ import {
 } from 'nostr-tools';
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
-import { storedIsLoggedin, storedLoginpubkey, storedTheme, storedRelaysSelected, storedFilterSelected } from '$lib/store';
+import { storedIsLoggedin, storedLoginpubkey, storedRelaysSelected, storedFilterSelected, preferences } from '$lib/store';
 import { urlDarkTheme, urlLightTheme, urlDefaultTheme, sendCreateChannel, type Channel, type Profile, type GetRelays } from '$lib/util';
 import { urlNIP07guide } from '$lib/config';
 import type { NostrAPI } from '$lib/@types/nostr';
@@ -28,7 +28,6 @@ export let pinList: string[];
 export let muteList: string[];
 export let muteChannels: string[];
 export let wordList: string[];
-
 let relaysSelected: string;
 storedRelaysSelected.subscribe((value) => {
 	relaysSelected = value;
@@ -38,8 +37,8 @@ storedFilterSelected.subscribe((value) => {
 	filterSelected = value;
 });
 
-storedTheme.subscribe((value) => {
-	theme = value;
+preferences.subscribe((value) => {
+	theme = value.theme ?? theme;
 });
 
 let newChannelName: string;
@@ -80,11 +79,11 @@ const callSendCreateChannel = () => {
 const changeTheme = () => {
 	const container = document.getElementById('container');
 	if(theme === urlDarkTheme) {
-		storedTheme.set(urlDarkTheme);
+		preferences.set({theme: urlDarkTheme});
 		container?.classList.remove('light');
 		container?.classList.add('dark');
 	} else {
-		storedTheme.set(urlLightTheme);
+		preferences.set({theme: urlLightTheme});
 		container?.classList.remove('dark');
 		container?.classList.add('light');
 	}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,14 +1,19 @@
 import type { nip19 } from 'nostr-tools';
 import { writable, type Writable } from 'svelte/store';
+import { persisted } from 'svelte-persisted-store';
+import { urlDefaultTheme } from './util';
 
 export const storedIsLoggedin = writable(false);
 export const storedLoginpubkey = writable('');
 export const storedRelaysSelected = writable('default');
 export const storedFilterSelected = writable('default');
 export const storedRelaysToUse = writable({});
-export const storedTheme = writable('');
 export const storedNeedApplyRelays = writable(false);
 export const storedCurrentChannelId: Writable<string | null> = writable('');
 export const storedCurrentPubkey: Writable<string | null> = writable('');
 export const storedCurrentEvent: Writable<nip19.EventPointer | null> = writable(null);
 export const storedCurrentHashtag: Writable<string | null> = writable('');
+
+export const preferences = persisted('preferences', {
+    theme: urlDefaultTheme
+});


### PR DESCRIPTION
https://github.com/nikolat/unyu-house/issues/75#issue-2036726829 の実装の提案です。

# 内容

ロード時には、htmlに書かれたコードが走り、localStorageに保存されたcssを読み込みます。

内部の動作は、テーマを`store`でなく`svelte-persisted-store`を使い、localStorageに値を保存していること、svelteでレンダされた`<link>`でなく、html上の`<link>`を変更しているところが変更点です。

# デメリット

htmlにスクリプトを直に書いているので、コードの分離がしずらく、扱いが煩雑になる可能性があります。